### PR TITLE
Switching to MuJoCo 2.1.0

### DIFF
--- a/.clang_complete
+++ b/.clang_complete
@@ -1,5 +1,5 @@
 -Iinclude
--Imjpro150/include
+-Imujoco210/include
 -std=gnu11
 -Wall
 -Wextra

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build/
 test/
-mjpro150/
+mujoco210/
 mjkey.txt
 *.so
 *.dll

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 PLATFORM := LINUX
 
 # Compilation settings
-INC     := -Iinclude -Imjpro150/include
+INC     := -Iinclude -Imujoco210/include
 CFLAGS  := -std=gnu11 -Wall -Wextra -O3 -march=sandybridge -flto
 LDFLAGS := -shared -Lsrc
 
@@ -37,7 +37,7 @@ build: $(LIBOUT)
 	cp -r model/* build/
 
 ctypes: build
-	clang2py include/*.h --clang-args="-I/usr/include/clang/6.0/include -Iinclude" -l ./$(LIBOUT) -o build/cassiemujoco_ctypes.py
+	clang2py include/*.h --clang-args="-I/usr/include/clang/10/include -Iinclude" -l ./$(LIBOUT) -o build/cassiemujoco_ctypes.py
 	sed -i '/import ctypes/aimport os\n_dir_path = os.path.dirname(os.path.realpath(__file__))' build/cassiemujoco_ctypes.py
 	sed -i "s/CDLL('.\/$(LIBOUT)')/CDLL(_dir_path + '\/$(LIBOUT)')/g" build/cassiemujoco_ctypes.py
 
@@ -45,8 +45,7 @@ test: checkdirs build
 	mkdir -p test
 	cp -r build/* test/
 	cp example/* test/
-	cp -r mjpro150 test/
-	cp mjkey.txt test/
+	cp -r mujoco210 test/
 	make -C test PLATFORM="$(PLATFORM)"
 
 # Virtual targets

--- a/README.md
+++ b/README.md
@@ -6,20 +6,17 @@ Developed and tested on Ubuntu 16.04. Also compiles for Windows using mingw-w64.
 To build the shared library:
 1.  Install libglfw3-dev
 2.  Clone this repository
-3.  Download mjpro150_linux.zip from roboti.us
-4.  Put mjpro150 in the cassie-mujoco-sim directory
+3.  Download mujoco210-linux-x86_64.tar.gz from mujoco.org
+4.  Put mujoco210 in the cassie-mujoco-sim directory
 5.  `make`
 
 To cross-compile for Windows, use `make PLATFORM=WIN`.
 
 A directory named release will be created containing the files needed to use the library with a C interface. A Python interface can be generated with `make ctypes`, which requires ctypeslib2 to be installed.
 
-A license file for MuJoCo (mjkey.txt) is required to run the simulation. The library also includes functions that can be used for communicating with Cassie over UDP, and MuJoCo is not required if only these functions are called.
-
 To build and run the examples:
-1.  Place mjkey.txt in the cassie-mujoco-sim directory
-2.  `make test`
-3.  Run the examples in the test directory
+1.  `make test`
+2.  Run the examples in the test directory
 
 The examples include cassiesim, which simulates a physical Cassie robot controlled over UDP, and cassiectrl, a null controller operating over UDP. The file cassietest.c is a minimal example of running the simulation, and cassietest.py demonstrates controlling the simulated robot in Python.
 

--- a/include/cassiemujoco.h
+++ b/include/cassiemujoco.h
@@ -35,7 +35,7 @@ extern "C" {
 #endif
 
 // Pass a null-terminated string containing the path to the directory
-// containing cassie.xml, mjpro150/, mjkey.txt, etc. If NULL is
+// containing cassie.xml, mujoco210/, mjkey.txt, etc. If NULL is
 // passed, the directory containing the current executable is used
 // instead. Returns true if loading was successful, false otherwise.
 bool cassie_mujoco_init(const char *basedir);

--- a/src/cassiemujoco.c
+++ b/src/cassiemujoco.c
@@ -112,7 +112,7 @@ GLFW_FUNCTION_LIST
 #define LOADLIB(path) LoadLibrary(path)
 #define UNLOADLIB(handle) FreeLibrary(handle)
 #define LOADFUN(handle, sym) sym ## _fp = (void*) GetProcAddress(handle, #sym)
-#define MJLIBNAME "mujoco150.dll"
+#define MJLIBNAME "mujoco210.dll"
 #define GLFWLIBNAME "glfw3.dll"
 
 #else
@@ -120,8 +120,8 @@ GLFW_FUNCTION_LIST
 #define LOADLIB(path) dlopen(path, RTLD_LAZY | RTLD_GLOBAL)
 #define UNLOADLIB(handle) dlclose(handle)
 #define LOADFUN(handle, sym) sym ## _fp = dlsym(handle, #sym)
-#define MJLIBNAME "libmujoco150.so"
-#define MJLIBNAMENOGL "libmujoco150nogl.so"
+#define MJLIBNAME "libmujoco210.so"
+#define MJLIBNAMENOGL "libmujoco210nogl.so"
 #define GLFWLIBNAME "libglfw.so.3"
 
 #endif
@@ -268,14 +268,14 @@ static bool load_glfw_library(const char *basedir)
 #ifndef _WIN32
     // Open dependencies
     gl_handle = LOADLIB("libGL.so.1");
-    snprintf(buf, sizeof buf, "%.4096s/mjpro150/bin/libglew.so", basedir);
+    snprintf(buf, sizeof buf, "%.4096s/mujoco210/bin/libglew.so", basedir);
     glew_handle = LOADLIB(buf);
     if (!gl_handle || !glew_handle)
         return false;
 #endif
 
     // Open library
-    snprintf(buf, sizeof buf, "%.4096s/mjpro150/bin/" GLFWLIBNAME, basedir);
+    snprintf(buf, sizeof buf, "%.4096s/mujoco210/bin/" GLFWLIBNAME, basedir);
     glfw_handle = LOADLIB(buf);
     if (!glfw_handle) {
         fprintf(stderr, "Failed to load %s\n", buf);
@@ -300,10 +300,10 @@ static bool load_mujoco_library(const char *basedir)
     bool __attribute__((unused)) gl = load_glfw_library(basedir);
 
     // Choose library version
-    snprintf(buf, sizeof buf, "%.4096s/mjpro150/bin/" MJLIBNAME, basedir);
+    snprintf(buf, sizeof buf, "%.4096s/mujoco210/bin/" MJLIBNAME, basedir);
 #ifndef _WIN32
     if (!gl)
-        snprintf(buf, sizeof buf, "%.4096s/mjpro150/bin/" MJLIBNAMENOGL, basedir);
+        snprintf(buf, sizeof buf, "%.4096s/mujoco210/bin/" MJLIBNAMENOGL, basedir);
 #endif
 
     // Open library
@@ -615,8 +615,10 @@ bool cassie_mujoco_init(const char *basedir)
             return false;
 
         // Activate MuJoCo
+		/*
         snprintf(buf, sizeof buf, "%.4096s/mjkey.txt", basedir);
         mj_activate_fp(buf);
+		*/
 
         // Load the model
         snprintf(buf, sizeof buf, "%.4096s/cassie.xml", basedir);
@@ -974,7 +976,7 @@ cassie_vis_t *cassie_vis_init()
         return NULL;
 
     // Allocate visualization structure
-    cassie_vis_t *v = malloc(sizeof (cassie_vis_t));
+    cassie_vis_t *v = calloc(1, sizeof (cassie_vis_t));
 
     // Create window
     v->window = glfwCreateWindow_fp(1200, 900, "Cassie", NULL, NULL);
@@ -986,7 +988,7 @@ cassie_vis_t *cassie_vis_init()
     v->cam.fixedcamid = 0;
     mjv_defaultOption_fp(&v->opt);
     mjr_defaultContext_fp(&v->con);
-    mjv_makeScene_fp(&v->scn, 1000);
+    mjv_makeScene_fp(initial_model, &v->scn, 1000);
     mjr_makeContext_fp(initial_model, &v->con, mjFONTSCALE_100);
 
     // Set callback for user-initiated window close events


### PR DESCRIPTION
This PR switched Cassie simulator to use MuJoCo 2.1.0, which, after
DeepMind acquisition is open-source and open access now.

Because mjv_makeScene will free the previous scn, switched v allocation
from malloc to calloc too. Otherwise using 2.1.0 will crash on start.

Test Plan:

Run `make test`, and run `test/cassietest.py`, before this PR, it
requires MuJoCo 1.5, now MuJoCo 2.1 worked and runs.